### PR TITLE
add koyo token

### DIFF
--- a/src/tokens/boba.json
+++ b/src/tokens/boba.json
@@ -120,7 +120,7 @@
     "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0xC6158B1989f89977bcc3150fC1F2eB2260F6cabE/logo.png"
   },
   {
-    "name": "Kōyō Token",
+    "name": "Koyo Token",
     "address": "0x618CC6549ddf12de637d46CDDadaFC0C2951131C",
     "symbol": "KYO",
     "decimals": 18,

--- a/src/tokens/boba.json
+++ b/src/tokens/boba.json
@@ -121,10 +121,10 @@
   },
   {
     "name": "Kōyō Token",
-    "address": "0x2F11899C848Ac0251D1F168cB658a44Eef97F2EA",
+    "address": "0x618CC6549ddf12de637d46CDDadaFC0C2951131C",
     "symbol": "KYO",
     "decimals": 18,
     "chainId": 288,
-    "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0x2F11899C848Ac0251D1F168cB658a44Eef97F2EA/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0x618CC6549ddf12de637d46CDDadaFC0C2951131C/logo.png"
   }
 ]

--- a/src/tokens/boba.json
+++ b/src/tokens/boba.json
@@ -110,7 +110,7 @@
     "decimals": 18,
     "chainId": 288,
     "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0x70bf3c5B5d80C4Fece8Bde0fCe7ef38B688463d4/logo.png"
-  },  
+  },
   {
     "name": "Boba WAGMI v3 Option",
     "address": "0xC6158B1989f89977bcc3150fC1F2eB2260F6cabE",
@@ -118,5 +118,13 @@
     "decimals": 18,
     "chainId": 288,
     "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0xC6158B1989f89977bcc3150fC1F2eB2260F6cabE/logo.png"
+  },
+  {
+    "name": "Kōyō Token",
+    "address": "0x2F11899C848Ac0251D1F168cB658a44Eef97F2EA",
+    "symbol": "KYO",
+    "decimals": 18,
+    "chainId": 288,
+    "logoURI": "https://raw.githubusercontent.com/OolongSwap/token-logos/main/288/0x2F11899C848Ac0251D1F168cB658a44Eef97F2EA/logo.png"
   }
 ]


### PR DESCRIPTION
Mainnet address: `0x618CC6549ddf12de637d46CDDadaFC0C2951131C`
 * We can't verify our contract on the Block explorer (Blockscout) as the variant deployed by Boba doesn't support Vyper (and neither does Soucify). The code for the token can be viewed on Github https://github.com/koyo-finance/koyo/blob/main/contracts/Koyo.vy

Website link: https://koyo.finance/
Social media link: https://twitter.com/koyofinance